### PR TITLE
Loyalty points implemetation

### DIFF
--- a/app/routes/cashier.tsx
+++ b/app/routes/cashier.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import { Form, redirect, useLoaderData, useNavigate, useFetcher } from "react-router";
 import type { Route } from "./+types/cashier";
 import pool from "../db.server";
@@ -76,6 +76,19 @@ export async function action({ request }: Route.ActionArgs) {
     });
   }
 
+  if (intent === "lookup-customer") {
+    await requireCashierAccess(request);
+    const phone = String(formData.get("phone") || "").trim();
+    if (!phone) return { ok: false as const, error: "Phone required" };
+    const { rows } = await pool.query(
+      `SELECT customer_id::text AS id, name, COALESCE(points, 0)::int AS points
+       FROM "Customer" WHERE phone_number = $1 LIMIT 1`,
+      [phone]
+    );
+    if (rows.length === 0) return { notFound: true as const };
+    return { customer: rows[0] as { id: string; name: string; points: number } };
+  }
+
   await requireCashierAccess(request);
   const items = JSON.parse(formData.get("cart") as string) as Array<{
     id: string; price: number; qty: number;
@@ -88,21 +101,38 @@ export async function action({ request }: Route.ActionArgs) {
   const session = await getCashierSession(request);
   const sessionEmployeeId = session.get("cashier:employeeId") as string | undefined;
 
-  const [empRow, custRow] = await Promise.all([
-    sessionEmployeeId
-      ? pool.query(
-          `SELECT employee_id
-           FROM "Employee"
-           WHERE employee_id = $1::uuid
-           LIMIT 1`,
-          [sessionEmployeeId]
-        )
-      : pool.query(`SELECT employee_id FROM "Employee" LIMIT 1`),
-    pool.query(`SELECT customer_id FROM "Customer" LIMIT 1`),
-  ]);
+  const formCustomerId    = String(formData.get("customerId")    || "").trim();
+  const formCustomerPhone = String(formData.get("customerPhone") || "").trim();
+
+  const empRow = await (sessionEmployeeId
+    ? pool.query(`SELECT employee_id FROM "Employee" WHERE employee_id = $1::uuid LIMIT 1`, [sessionEmployeeId])
+    : pool.query(`SELECT employee_id FROM "Employee" LIMIT 1`));
   const employeeId = empRow.rows[0]?.employee_id;
-  const customerId = custRow.rows[0]?.customer_id;
-  if (!employeeId || !customerId) return { ok: false, error: "No employee or customer record found" };
+  if (!employeeId) return { ok: false, error: "No employee record found" };
+
+  let customerId: string;
+  if (formCustomerId) {
+    customerId = formCustomerId;
+  } else if (formCustomerPhone) {
+    const existing = await pool.query(
+      `SELECT customer_id FROM "Customer" WHERE phone_number = $1 LIMIT 1`,
+      [formCustomerPhone]
+    );
+    if (existing.rows.length > 0) {
+      customerId = existing.rows[0].customer_id;
+    } else {
+      const created = await pool.query(
+        `INSERT INTO "Customer" (customer_id, name, phone_number, points)
+         VALUES (gen_random_uuid(), $1, $2, 0) RETURNING customer_id`,
+        [customerName, formCustomerPhone]
+      );
+      customerId = created.rows[0].customer_id;
+    }
+  } else {
+    const fallback = await pool.query(`SELECT customer_id FROM "Customer" LIMIT 1`);
+    customerId = fallback.rows[0]?.customer_id;
+    if (!customerId) return { ok: false, error: "No customer record found" };
+  }
 
   const subtotal   = items.reduce((s, i) => s + i.price * i.qty, 0);
   const totalPrice = applyTax(subtotal);
@@ -187,7 +217,8 @@ interface OrderItem {
 export default function Cashier() {
   const navigate = useNavigate();
   const { categories, byCategory } = useLoaderData<typeof loader>();
-  const fetcher = useFetcher<typeof action>();
+  const fetcher       = useFetcher<typeof action>();
+  const lookupFetcher = useFetcher<typeof action>();
 
   const translationContext = useContext(TranslationContext);
   const language = translationContext?.language ?? "en";
@@ -226,14 +257,31 @@ export default function Cashier() {
   const [iceLevel, setIceLevel]                 = useState("Regular");
   const [selectedToppings, setSelectedToppings] = useState<number[]>([]);
   const [customerName, setCustomerName]         = useState("");
+  const [customerPhone, setCustomerPhone]       = useState("");
+  const [lookedUpCustomer, setLookedUpCustomer] = useState<{ id: string; name: string; points: number } | "not-found" | null>(null);
 
   // Clear cart on successful order
   useEffect(() => {
-    if (fetcher.state === "idle" && fetcher.data?.ok) {
+    if (fetcher.state === "idle" && fetcher.data && "ok" in fetcher.data && fetcher.data.ok) {
       setOrderItems([]);
       setCustomerName("");
+      setCustomerPhone("");
+      setLookedUpCustomer(null);
     }
   }, [fetcher.state, fetcher.data]);
+
+  // Handle customer phone lookup result
+  useEffect(() => {
+    const data = lookupFetcher.data;
+    if (!data || lookupFetcher.state !== "idle") return;
+    if ("customer" in data) {
+      const c = data.customer as { id: string; name: string; points: number };
+      setLookedUpCustomer(c);
+      setCustomerName(c.name);
+    } else if ("notFound" in data) {
+      setLookedUpCustomer("not-found");
+    }
+  }, [lookupFetcher.state, lookupFetcher.data]);
 
   const openItem = (item: CashierMenuItem) => {
     setSelectedItem(item);
@@ -274,16 +322,27 @@ export default function Cashier() {
   const total    = subtotal + tax;
   const submitting = fetcher.state !== "idle";
 
+  const handleLookup = () => {
+    if (!customerPhone.trim()) return;
+    lookupFetcher.submit(
+      { intent: "lookup-customer", phone: customerPhone.trim() },
+      { method: "post" }
+    );
+  };
+
   const handleSubmit = () => {
     if (orderItems.length === 0) return;
     if (!customerName.trim()) return;
-    fetcher.submit(
-      {
-        cart: JSON.stringify(orderItems.map((i) => ({ id: i.id, price: i.price, qty: i.qty }))),
-        customerName: customerName.trim(),
-      },
-      { method: "post" }
-    );
+    const payload: Record<string, string> = {
+      cart: JSON.stringify(orderItems.map((i) => ({ id: i.id, price: i.price, qty: i.qty }))),
+      customerName: customerName.trim(),
+    };
+    if (lookedUpCustomer && lookedUpCustomer !== "not-found") {
+      payload.customerId = lookedUpCustomer.id;
+    } else if (customerPhone.trim()) {
+      payload.customerPhone = customerPhone.trim();
+    }
+    fetcher.submit(payload, { method: "post" });
   };
 
   const items = byCategory[activeCategory] ?? [];
@@ -394,8 +453,38 @@ export default function Cashier() {
           </div>
 
           <div className="px-4 py-4 border-t border-slate-200 space-y-2 text-sm">
+            <div className="space-y-1.5">
+              <span className="block text-xs font-medium text-slate-600">Phone Number</span>
+              <div className="flex gap-2">
+                <input
+                  type="tel"
+                  value={customerPhone}
+                  onChange={(e) => { setCustomerPhone(e.target.value); setLookedUpCustomer(null); }}
+                  placeholder="555-867-5309"
+                  className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                />
+                <button
+                  type="button"
+                  onClick={handleLookup}
+                  disabled={!customerPhone.trim() || lookupFetcher.state !== "idle"}
+                  className="secondary-btn px-3 py-2 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {lookupFetcher.state !== "idle" ? "…" : "Look up"}
+                </button>
+              </div>
+              {lookedUpCustomer === "not-found" && (
+                <p className="text-xs text-amber-600">No member found — enter a name below to create one.</p>
+              )}
+              {lookedUpCustomer && lookedUpCustomer !== "not-found" && (
+                <p className="text-xs text-emerald-600 font-medium">
+                  Found: {lookedUpCustomer.name} · {lookedUpCustomer.points} pts
+                </p>
+              )}
+            </div>
             <label className="block text-slate-600">
-              <span className="mb-1 block">Customer Name</span>
+              <span className="mb-1 block text-xs font-medium">
+                {lookedUpCustomer === "not-found" ? "Customer Name (new member)" : "Customer Name"}
+              </span>
               <input
                 type="text"
                 value={customerName}
@@ -420,9 +509,9 @@ export default function Cashier() {
             >
               {submitting ? "Submitting…" : "Submit Order"}
             </button>
-            {fetcher.data && !fetcher.data.ok && (
+            {"ok" in (fetcher.data ?? {}) && !(fetcher.data as { ok: boolean }).ok && (
               <p className="text-xs text-red-600 mt-1 text-center">
-                {"error" in fetcher.data ? fetcher.data.error : "Failed to submit order"}
+                {"error" in fetcher.data! ? (fetcher.data as { error: string }).error : "Failed to submit order"}
               </p>
             )}
           </div>

--- a/app/routes/cashier.tsx
+++ b/app/routes/cashier.tsx
@@ -32,6 +32,8 @@ const TOPPINGS: Topping[] = [
   { id: 17, name: "Pudding",      price: 0.75 },
 ];
 
+const normalizePhone = (p: string) => p.replace(/\D/g, "");
+
 export async function loader({ request }: Route.LoaderArgs) {
   await requireCashierAccess(request);
   const result = await pool.query(
@@ -78,7 +80,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   if (intent === "lookup-customer") {
     await requireCashierAccess(request);
-    const phone = String(formData.get("phone") || "").trim();
+    const phone = normalizePhone(String(formData.get("phone") || ""));
     if (!phone) return { ok: false as const, error: "Phone required" };
     const { rows } = await pool.query(
       `SELECT customer_id::text AS id, name, COALESCE(points, 0)::int AS points
@@ -102,7 +104,7 @@ export async function action({ request }: Route.ActionArgs) {
   const sessionEmployeeId = session.get("cashier:employeeId") as string | undefined;
 
   const formCustomerId    = String(formData.get("customerId")    || "").trim();
-  const formCustomerPhone = String(formData.get("customerPhone") || "").trim();
+  const formCustomerPhone = normalizePhone(String(formData.get("customerPhone") || ""));
 
   const empRow = await (sessionEmployeeId
     ? pool.query(`SELECT employee_id FROM "Employee" WHERE employee_id = $1::uuid LIMIT 1`, [sessionEmployeeId])
@@ -111,8 +113,10 @@ export async function action({ request }: Route.ActionArgs) {
   if (!employeeId) return { ok: false, error: "No employee record found" };
 
   let customerId: string;
+  let earnPoints = false;
   if (formCustomerId) {
     customerId = formCustomerId;
+    earnPoints = true;
   } else if (formCustomerPhone) {
     const existing = await pool.query(
       `SELECT customer_id FROM "Customer" WHERE phone_number = $1 LIMIT 1`,
@@ -128,6 +132,7 @@ export async function action({ request }: Route.ActionArgs) {
       );
       customerId = created.rows[0].customer_id;
     }
+    earnPoints = true;
   } else {
     const fallback = await pool.query(`SELECT customer_id FROM "Customer" LIMIT 1`);
     customerId = fallback.rows[0]?.customer_id;
@@ -165,6 +170,13 @@ export async function action({ request }: Route.ActionArgs) {
        VALUES (gen_random_uuid(), CURRENT_DATE, now(), 'SALE', $1, $2, $3, 'Cash', $4)`,
       [orderId, totalPrice.toFixed(2), taxAmount, totalQty]
     );
+    if (earnPoints) {
+      await client.query(
+        `UPDATE "Customer" SET points = points + floor($1::numeric) WHERE customer_id = $2::uuid`,
+        [totalPrice.toFixed(2), customerId]
+      );
+    }
+
     await client.query("COMMIT");
   } catch (error) {
     await client.query("ROLLBACK");

--- a/app/routes/cashier.tsx
+++ b/app/routes/cashier.tsx
@@ -193,7 +193,6 @@ async function getNextOrderNumber(client: PoolClient) {
   return rows[0]?.next_order_number ?? 1;
 }
 
-const TAX_RATE = 0.0825;
 
 interface CashierMenuItem {
   id:      string;

--- a/app/routes/cashier.tsx
+++ b/app/routes/cashier.tsx
@@ -143,6 +143,12 @@ export async function action({ request }: Route.ActionArgs) {
   const totalPrice = applyTax(subtotal);
   const totalQty   = items.reduce((s, i) => s + i.qty, 0);
 
+  const redeem300Count = Math.max(0, parseInt(String(formData.get("redeem300") || "0"), 10));
+  const redeem100Count = Math.max(0, parseInt(String(formData.get("redeem100") || "0"), 10));
+  const pointsRedeemed = earnPoints ? redeem300Count * 300 + redeem100Count * 100 : 0;
+  const redeemDiscount = earnPoints ? redeem300Count * 4  + redeem100Count * 1   : 0;
+  const discountedTotal = Math.max(0, totalPrice - redeemDiscount);
+
   const client = await pool.connect();
   let orderId: string;
   try {
@@ -151,7 +157,7 @@ export async function action({ request }: Route.ActionArgs) {
     const { rows } = await client.query(
       `INSERT INTO "Order" (order_id, employee_id, customer_id, date, total_price, payment_method, item_quantity, customer_name, order_number)
        VALUES (gen_random_uuid(), $1, $2, now(), $3, 'Cash', $4, $5, $6) RETURNING order_id`,
-      [employeeId, customerId, totalPrice.toFixed(2), totalQty, customerName, orderNumber]
+      [employeeId, customerId, discountedTotal.toFixed(2), totalQty, customerName, orderNumber]
     );
     orderId = rows[0].order_id;
 
@@ -172,8 +178,8 @@ export async function action({ request }: Route.ActionArgs) {
     );
     if (earnPoints) {
       await client.query(
-        `UPDATE "Customer" SET points = points + floor($1::numeric) WHERE customer_id = $2::uuid`,
-        [totalPrice.toFixed(2), customerId]
+        `UPDATE "Customer" SET points = points + floor($1::numeric * 5) - $2 WHERE customer_id = $3::uuid`,
+        [discountedTotal.toFixed(2), pointsRedeemed, customerId]
       );
     }
 
@@ -275,6 +281,8 @@ export default function Cashier() {
   const [customerName, setCustomerName]         = useState("");
   const [customerPhone, setCustomerPhone]       = useState("");
   const [lookedUpCustomer, setLookedUpCustomer] = useState<{ id: string; name: string; points: number } | "not-found" | null>(null);
+  const [redeem300, setRedeem300]               = useState(0);
+  const [redeem100, setRedeem100]               = useState(0);
 
   // Clear cart on successful order
   useEffect(() => {
@@ -283,6 +291,8 @@ export default function Cashier() {
       setCustomerName("");
       setCustomerPhone("");
       setLookedUpCustomer(null);
+      setRedeem300(0);
+      setRedeem100(0);
     }
   }, [fetcher.state, fetcher.data]);
 
@@ -341,10 +351,22 @@ export default function Cashier() {
 
   const removeItem = (cartKey: string) => setOrderItems((prev) => prev.filter((o) => o.cartKey !== cartKey));
 
-  const subtotal = orderItems.reduce((sum, i) => sum + i.price * i.qty, 0);
-  const tax      = subtotal * TAX_RATE;
-  const total    = subtotal + tax;
-  const submitting = fetcher.state !== "idle";
+  const subtotal        = orderItems.reduce((sum, i) => sum + i.price * i.qty, 0);
+  const tax             = subtotal * TAX_RATE;
+  const total           = subtotal + tax;
+  const availablePoints = lookedUpCustomer && lookedUpCustomer !== "not-found" ? lookedUpCustomer.points : 0;
+  const pointsUsed      = redeem300 * 300 + redeem100 * 100;
+  const remainingPoints = availablePoints - pointsUsed;
+  const redeemDiscount  = redeem300 * 4 + redeem100 * 1;
+  const adjustedTotal   = Math.max(0, total - redeemDiscount);
+  const submitting      = fetcher.state !== "idle";
+
+  const applyAllPoints = () => {
+    const max300 = Math.floor(availablePoints / 300);
+    const max100 = Math.floor((availablePoints - max300 * 300) / 100);
+    setRedeem300(max300);
+    setRedeem100(max100);
+  };
 
   const handleLookup = () => {
     if (!customerPhone.trim()) return;
@@ -360,6 +382,8 @@ export default function Cashier() {
     const payload: Record<string, string> = {
       cart: JSON.stringify(orderItems.map((i) => ({ id: i.id, price: i.price, qty: i.qty }))),
       customerName: customerName.trim(),
+      redeem300: String(redeem300),
+      redeem100: String(redeem100),
     };
     if (lookedUpCustomer && lookedUpCustomer !== "not-found") {
       payload.customerId = lookedUpCustomer.id;
@@ -517,14 +541,51 @@ export default function Cashier() {
                 placeholder="Enter customer name"
               />
             </label>
+            {lookedUpCustomer && lookedUpCustomer !== "not-found" && availablePoints >= 100 && (
+              <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold text-indigo-700">Redeem Points</span>
+                  <span className="text-xs text-indigo-500">{remainingPoints} pts left</span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  <button type="button" onClick={() => setRedeem300(r => r + 1)}
+                    disabled={remainingPoints < 300}
+                    className="text-xs px-2 py-1 rounded border border-indigo-300 bg-white text-indigo-700 hover:bg-indigo-100 disabled:opacity-40 disabled:cursor-not-allowed">
+                    300 pts → $4 off
+                  </button>
+                  <button type="button" onClick={() => setRedeem100(r => r + 1)}
+                    disabled={remainingPoints < 100}
+                    className="text-xs px-2 py-1 rounded border border-indigo-300 bg-white text-indigo-700 hover:bg-indigo-100 disabled:opacity-40 disabled:cursor-not-allowed">
+                    100 pts → $1 off
+                  </button>
+                  <button type="button" onClick={applyAllPoints}
+                    disabled={availablePoints < 100}
+                    className="text-xs px-2 py-1 rounded border border-indigo-300 bg-white text-indigo-700 hover:bg-indigo-100 disabled:opacity-40 disabled:cursor-not-allowed">
+                    Apply All
+                  </button>
+                </div>
+                {pointsUsed > 0 && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-indigo-600">{pointsUsed} pts → -${redeemDiscount.toFixed(2)} off</span>
+                    <button type="button" onClick={() => { setRedeem300(0); setRedeem100(0); }}
+                      className="text-xs text-slate-400 hover:text-red-500">Clear</button>
+                  </div>
+                )}
+              </div>
+            )}
             <div className="flex justify-between text-slate-600">
               <span>Subtotal</span><span>${subtotal.toFixed(2)}</span>
             </div>
             <div className="flex justify-between text-slate-600">
               <span>Tax (8.25%)</span><span>${tax.toFixed(2)}</span>
             </div>
+            {redeemDiscount > 0 && (
+              <div className="flex justify-between text-emerald-600 text-xs">
+                <span>Points discount</span><span>-${redeemDiscount.toFixed(2)}</span>
+              </div>
+            )}
             <div className="flex justify-between font-bold text-slate-900 text-base pt-1 border-t border-slate-200">
-              <span>Total</span><span>${total.toFixed(2)}</span>
+              <span>Total</span><span>${adjustedTotal.toFixed(2)}</span>
             </div>
             <button
               onClick={handleSubmit}

--- a/app/routes/customer.tsx
+++ b/app/routes/customer.tsx
@@ -1,3 +1,4 @@
+// Customer ordering kiosk
 import { useState, useEffect } from "react";
 import { useLoaderData, useNavigate, useFetcher } from "react-router";
 import type { Route } from "./+types/customer";
@@ -97,19 +98,57 @@ export async function loader() {
 
 export async function action({ request }: Route.ActionArgs) {
   const formData = await request.formData();
+  const intent = String(formData.get("intent") || "");
+
+  if (intent === "lookup-customer") {
+    const phone = String(formData.get("phone") || "").trim();
+    if (!phone) return { ok: false as const, error: "Phone required" };
+    const { rows } = await pool.query(
+      `SELECT customer_id::text AS id, name, COALESCE(points, 0)::int AS points
+       FROM "Customer" WHERE phone_number = $1 LIMIT 1`,
+      [phone]
+    );
+    if (rows.length === 0) return { notFound: true as const };
+    return { customer: rows[0] as { id: string; name: string; points: number } };
+  }
+
   const items = JSON.parse(formData.get("cart") as string) as Array<{
     id: string; basePrice: number; qty: number;
   }>;
 
   if (!items.length) return { ok: false };
 
-  const [empRow, custRow] = await Promise.all([
-    pool.query(`SELECT employee_id FROM "Employee" LIMIT 1`),
-    pool.query(`SELECT customer_id FROM "Customer" LIMIT 1`),
-  ]);
+  const formCustomerId    = String(formData.get("customerId")    || "").trim();
+  const formCustomerPhone = String(formData.get("customerPhone") || "").trim();
+  const formCustomerName  = String(formData.get("customerName")  || "").trim() || "Kiosk Customer";
+
+  const empRow = await pool.query(`SELECT employee_id FROM "Employee" LIMIT 1`);
   const employeeId = empRow.rows[0]?.employee_id;
-  const customerId = custRow.rows[0]?.customer_id;
-  if (!employeeId || !customerId) return { ok: false, error: "No employee or customer record found" };
+  if (!employeeId) return { ok: false, error: "No employee record found" };
+
+  let customerId: string;
+  if (formCustomerId) {
+    customerId = formCustomerId;
+  } else if (formCustomerPhone) {
+    const existing = await pool.query(
+      `SELECT customer_id FROM "Customer" WHERE phone_number = $1 LIMIT 1`,
+      [formCustomerPhone]
+    );
+    if (existing.rows.length > 0) {
+      customerId = existing.rows[0].customer_id;
+    } else {
+      const created = await pool.query(
+        `INSERT INTO "Customer" (customer_id, name, phone_number, points)
+         VALUES (gen_random_uuid(), $1, $2, 0) RETURNING customer_id`,
+        [formCustomerName, formCustomerPhone]
+      );
+      customerId = created.rows[0].customer_id;
+    }
+  } else {
+    const fallback = await pool.query(`SELECT customer_id FROM "Customer" LIMIT 1`);
+    customerId = fallback.rows[0]?.customer_id;
+    if (!customerId) return { ok: false, error: "No customer record found" };
+  }
 
   // Group by item_id — same item with different customizations shares a DB row
   const grouped: Record<string, { price: number; qty: number }> = {};
@@ -131,8 +170,8 @@ export async function action({ request }: Route.ActionArgs) {
     const orderNumber = await getNextOrderNumber(client);
     const { rows } = await client.query(
       `INSERT INTO "Order" (order_id, employee_id, customer_id, date, total_price, payment_method, item_quantity, customer_name, order_number)
-       VALUES (gen_random_uuid(), $1, $2, now(), $3, 'Cash', $4, 'Kiosk Customer', $5) RETURNING order_id`,
-      [employeeId, customerId, totalPrice.toFixed(2), totalQty, orderNumber]
+       VALUES (gen_random_uuid(), $1, $2, now(), $3, 'Cash', $4, $5, $6) RETURNING order_id`,
+      [employeeId, customerId, totalPrice.toFixed(2), totalQty, formCustomerName, orderNumber]
     );
     const orderId = rows[0].order_id;
 
@@ -183,20 +222,36 @@ async function getNextOrderNumber(client: PoolClient) {
 export default function Customer() {
   const navigate = useNavigate();
   const { categories, menuItems } = useLoaderData<typeof loader>();
-  const fetcher = useFetcher<typeof action>();
+  const fetcher       = useFetcher<typeof action>();
+  const lookupFetcher = useFetcher<typeof action>();
 
   const [activeCategory, setActiveCategory] = useState(0); // index of category
   const [blockedAllergens, setBlockedAllergens] = useState<string[]>([]);
   const [cart, setCart]                     = useState<CartItem[]>([]);
   const [showCart, setShowCart]             = useState(false);
+  const [customerPhone, setCustomerPhone]       = useState("");
+  const [lookedUpCustomer, setLookedUpCustomer] = useState<{ id: string; name: string; points: number } | "not-found" | null>(null);
 
   // Clear cart on successful order
   useEffect(() => {
-    if (fetcher.state === "idle" && fetcher.data?.ok) {
+    if (fetcher.state === "idle" && fetcher.data && "ok" in fetcher.data && fetcher.data.ok) {
       setCart([]);
       setShowCart(false);
+      setCustomerPhone("");
+      setLookedUpCustomer(null);
     }
   }, [fetcher.state, fetcher.data]);
+
+  // Handle phone lookup result
+  useEffect(() => {
+    const data = lookupFetcher.data;
+    if (!data || lookupFetcher.state !== "idle") return;
+    if ("customer" in data) {
+      setLookedUpCustomer(data.customer as { id: string; name: string; points: number });
+    } else if ("notFound" in data) {
+      setLookedUpCustomer("not-found");
+    }
+  }, [lookupFetcher.state, lookupFetcher.data]);
   const [selectedItem, setSelectedItem]         = useState<MenuItem | null>(null);
   const [milkLevel, setMilkLevel]               = useState("Whole Milk");
   const [iceLevel, setIceLevel]                 = useState("Regular");
@@ -398,19 +453,61 @@ export default function Customer() {
                 <div className="mt-4 flex items-center justify-between font-bold text-slate-900 text-base">
                   <span>Total</span><span>${total.toFixed(2)}</span>
                 </div>
-                <button
-                  onClick={() => fetcher.submit(
-                    { cart: JSON.stringify(cart.map((i) => ({ id: i.id, basePrice: i.basePrice, qty: i.qty }))) },
-                    { method: "post" }
+                <div className="mt-4 space-y-2">
+                  <span className="block text-xs font-medium text-slate-600">Phone Number (optional — earn loyalty points)</span>
+                  <div className="flex gap-2">
+                    <input
+                      type="tel"
+                      value={customerPhone}
+                      onChange={(e) => { setCustomerPhone(e.target.value); setLookedUpCustomer(null); }}
+                      placeholder="555-867-5309"
+                      className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!customerPhone.trim()) return;
+                        lookupFetcher.submit(
+                          { intent: "lookup-customer", phone: customerPhone.trim() },
+                          { method: "post" }
+                        );
+                      }}
+                      disabled={!customerPhone.trim() || lookupFetcher.state !== "idle"}
+                      className="secondary-btn px-3 py-2 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {lookupFetcher.state !== "idle" ? "…" : "Look up"}
+                    </button>
+                  </div>
+                  {lookedUpCustomer === "not-found" && (
+                    <p className="text-xs text-amber-600">No account found — a new one will be created for this number.</p>
                   )}
+                  {lookedUpCustomer && lookedUpCustomer !== "not-found" && (
+                    <p className="text-xs text-emerald-600 font-medium">
+                      Welcome back, {lookedUpCustomer.name}! · {lookedUpCustomer.points} pts
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() => {
+                    const payload: Record<string, string> = {
+                      cart: JSON.stringify(cart.map((i) => ({ id: i.id, basePrice: i.basePrice, qty: i.qty }))),
+                    };
+                    if (lookedUpCustomer && lookedUpCustomer !== "not-found") {
+                      payload.customerId    = lookedUpCustomer.id;
+                      payload.customerName  = lookedUpCustomer.name;
+                    } else if (customerPhone.trim()) {
+                      payload.customerPhone = customerPhone.trim();
+                    }
+                    fetcher.submit(payload, { method: "post" });
+                  }}
                   disabled={fetcher.state !== "idle"}
                   className="primary-btn mt-4 w-full py-3 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed"
                 >
                   {fetcher.state !== "idle" ? "Placing order…" : "Place Order"}
                 </button>
-                {fetcher.data && !fetcher.data.ok && (
+                {"ok" in (fetcher.data ?? {}) && !(fetcher.data as { ok: boolean }).ok && (
                   <p className="text-xs text-red-600 mt-2 text-center">
-                    {"error" in fetcher.data ? fetcher.data.error : "Failed to place order"}
+                    {"error" in fetcher.data! ? (fetcher.data as { error: string }).error : "Failed to place order"}
                   </p>
                 )}
               </>

--- a/app/routes/customer.tsx
+++ b/app/routes/customer.tsx
@@ -165,9 +165,15 @@ export async function action({ request }: Route.ActionArgs) {
     }
   }
 
-  const totalQty   = items.reduce((s, i) => s + i.qty, 0);
+  const totalQty    = items.reduce((s, i) => s + i.qty, 0);
   const subtotalRaw = items.reduce((s, i) => s + i.basePrice * i.qty, 0);
-  const totalPrice = applyTax(subtotalRaw);
+  const totalPrice  = applyTax(subtotalRaw);
+
+  const redeem300Count = Math.max(0, parseInt(String(formData.get("redeem300") || "0"), 10));
+  const redeem100Count = Math.max(0, parseInt(String(formData.get("redeem100") || "0"), 10));
+  const pointsRedeemed  = earnPoints ? redeem300Count * 300 + redeem100Count * 100 : 0;
+  const redeemDiscount  = earnPoints ? redeem300Count * 4  + redeem100Count * 1   : 0;
+  const discountedTotal = Math.max(0, totalPrice - redeemDiscount);
 
   const client = await pool.connect();
   try {
@@ -176,7 +182,7 @@ export async function action({ request }: Route.ActionArgs) {
     const { rows } = await client.query(
       `INSERT INTO "Order" (order_id, employee_id, customer_id, date, total_price, payment_method, item_quantity, customer_name, order_number)
        VALUES (gen_random_uuid(), $1, $2, now(), $3, 'Cash', $4, $5, $6) RETURNING order_id`,
-      [employeeId, customerId, totalPrice.toFixed(2), totalQty, formCustomerName, orderNumber]
+      [employeeId, customerId, discountedTotal.toFixed(2), totalQty, formCustomerName, orderNumber]
     );
     const orderId = rows[0].order_id;
 
@@ -198,8 +204,8 @@ export async function action({ request }: Route.ActionArgs) {
     );
     if (earnPoints) {
       await client.query(
-        `UPDATE "Customer" SET points = points + floor($1::numeric) WHERE customer_id = $2::uuid`,
-        [totalPrice.toFixed(2), customerId]
+        `UPDATE "Customer" SET points = points + floor($1::numeric * 5) - $2 WHERE customer_id = $3::uuid`,
+        [discountedTotal.toFixed(2), pointsRedeemed, customerId]
       );
     }
 
@@ -246,6 +252,8 @@ export default function Customer() {
   const [showCart, setShowCart]             = useState(false);
   const [customerPhone, setCustomerPhone]       = useState("");
   const [lookedUpCustomer, setLookedUpCustomer] = useState<{ id: string; name: string; points: number } | "not-found" | null>(null);
+  const [redeem300, setRedeem300]               = useState(0);
+  const [redeem100, setRedeem100]               = useState(0);
 
   // Clear cart on successful order
   useEffect(() => {
@@ -254,6 +262,8 @@ export default function Customer() {
       setShowCart(false);
       setCustomerPhone("");
       setLookedUpCustomer(null);
+      setRedeem300(0);
+      setRedeem100(0);
     }
   }, [fetcher.state, fetcher.data]);
 
@@ -389,8 +399,20 @@ export default function Customer() {
   const removeFromCart = (cartKey: string) =>
     setCart((prev) => prev.filter((c) => c.cartKey !== cartKey));
 
-  const totalItems = cart.reduce((s, c) => s + c.qty, 0);
-  const total      = cart.reduce((s, c) => s + c.price * c.qty, 0);
+  const totalItems      = cart.reduce((s, c) => s + c.qty, 0);
+  const total           = cart.reduce((s, c) => s + c.price * c.qty, 0);
+  const availablePoints = lookedUpCustomer && lookedUpCustomer !== "not-found" ? lookedUpCustomer.points : 0;
+  const pointsUsed      = redeem300 * 300 + redeem100 * 100;
+  const remainingPoints = availablePoints - pointsUsed;
+  const redeemDiscount  = redeem300 * 4 + redeem100 * 1;
+  const adjustedTotal   = Math.max(0, total - redeemDiscount);
+
+  const applyAllPoints = () => {
+    const max300 = Math.floor(availablePoints / 300);
+    const max100 = Math.floor((availablePoints - max300 * 300) / 100);
+    setRedeem300(max300);
+    setRedeem100(max100);
+  };
 
   return (
     <div className="h-screen flex flex-col app-shell">
@@ -475,8 +497,42 @@ export default function Customer() {
                   ))}
                 </div>
                 <div className="mt-4 flex items-center justify-between font-bold text-slate-900 text-base">
-                  <span>Total</span><span>${total.toFixed(2)}</span>
+                  <span>Total</span><span>${adjustedTotal.toFixed(2)}</span>
                 </div>
+                {redeemDiscount > 0 && (
+                  <p className="text-xs text-emerald-600 text-right">-${redeemDiscount.toFixed(2)} points discount applied</p>
+                )}
+                {lookedUpCustomer && lookedUpCustomer !== "not-found" && availablePoints >= 100 && (
+                  <div className="mt-4 rounded-lg border border-indigo-200 bg-indigo-50 p-3 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold text-indigo-700">Redeem Points</span>
+                      <span className="text-xs text-indigo-500">{remainingPoints} pts left</span>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      <button type="button" onClick={() => setRedeem300(r => r + 1)}
+                        disabled={remainingPoints < 300}
+                        className="text-xs px-2 py-1.5 rounded border border-indigo-300 bg-white text-indigo-700 hover:bg-indigo-100 disabled:opacity-40 disabled:cursor-not-allowed">
+                        300 pts → $4 off
+                      </button>
+                      <button type="button" onClick={() => setRedeem100(r => r + 1)}
+                        disabled={remainingPoints < 100}
+                        className="text-xs px-2 py-1.5 rounded border border-indigo-300 bg-white text-indigo-700 hover:bg-indigo-100 disabled:opacity-40 disabled:cursor-not-allowed">
+                        100 pts → $1 off
+                      </button>
+                      <button type="button" onClick={applyAllPoints}
+                        className="text-xs px-2 py-1.5 rounded border border-indigo-300 bg-white text-indigo-700 hover:bg-indigo-100">
+                        Apply All
+                      </button>
+                    </div>
+                    {pointsUsed > 0 && (
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-indigo-600">{pointsUsed} pts → -${redeemDiscount.toFixed(2)} off</span>
+                        <button type="button" onClick={() => { setRedeem300(0); setRedeem100(0); }}
+                          className="text-xs text-slate-400 hover:text-red-500">Clear</button>
+                      </div>
+                    )}
+                  </div>
+                )}
                 <div className="mt-4 space-y-2">
                   <span className="block text-xs font-medium text-slate-600">Phone Number (optional — earn loyalty points)</span>
                   <div className="flex gap-2">
@@ -515,6 +571,8 @@ export default function Customer() {
                   onClick={() => {
                     const payload: Record<string, string> = {
                       cart: JSON.stringify(cart.map((i) => ({ id: i.id, basePrice: i.basePrice, qty: i.qty }))),
+                      redeem300: String(redeem300),
+                      redeem100: String(redeem100),
                     };
                     if (lookedUpCustomer && lookedUpCustomer !== "not-found") {
                       payload.customerId    = lookedUpCustomer.id;

--- a/app/routes/customer.tsx
+++ b/app/routes/customer.tsx
@@ -59,6 +59,8 @@ interface CartItem {
   toppings:  Topping[];
 }
 
+const normalizePhone = (p: string) => p.replace(/\D/g, "");
+
 export async function loader() {
   const result = await pool.query(
     `SELECT item_id::text AS id, name, category, price::float AS price, milk,
@@ -101,7 +103,7 @@ export async function action({ request }: Route.ActionArgs) {
   const intent = String(formData.get("intent") || "");
 
   if (intent === "lookup-customer") {
-    const phone = String(formData.get("phone") || "").trim();
+    const phone = normalizePhone(String(formData.get("phone") || ""));
     if (!phone) return { ok: false as const, error: "Phone required" };
     const { rows } = await pool.query(
       `SELECT customer_id::text AS id, name, COALESCE(points, 0)::int AS points
@@ -119,7 +121,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (!items.length) return { ok: false };
 
   const formCustomerId    = String(formData.get("customerId")    || "").trim();
-  const formCustomerPhone = String(formData.get("customerPhone") || "").trim();
+  const formCustomerPhone = normalizePhone(String(formData.get("customerPhone") || ""));
   const formCustomerName  = String(formData.get("customerName")  || "").trim() || "Kiosk Customer";
 
   const empRow = await pool.query(`SELECT employee_id FROM "Employee" LIMIT 1`);
@@ -127,8 +129,10 @@ export async function action({ request }: Route.ActionArgs) {
   if (!employeeId) return { ok: false, error: "No employee record found" };
 
   let customerId: string;
+  let earnPoints = false;
   if (formCustomerId) {
     customerId = formCustomerId;
+    earnPoints = true;
   } else if (formCustomerPhone) {
     const existing = await pool.query(
       `SELECT customer_id FROM "Customer" WHERE phone_number = $1 LIMIT 1`,
@@ -144,6 +148,7 @@ export async function action({ request }: Route.ActionArgs) {
       );
       customerId = created.rows[0].customer_id;
     }
+    earnPoints = true;
   } else {
     const fallback = await pool.query(`SELECT customer_id FROM "Customer" LIMIT 1`);
     customerId = fallback.rows[0]?.customer_id;
@@ -191,6 +196,13 @@ export async function action({ request }: Route.ActionArgs) {
        VALUES (gen_random_uuid(), CURRENT_DATE, now(), 'SALE', $1, $2, $3, 'Cash', $4)`,
       [orderId, totalPrice.toFixed(2), taxAmount, totalQty]
     );
+    if (earnPoints) {
+      await client.query(
+        `UPDATE "Customer" SET points = points + floor($1::numeric) WHERE customer_id = $2::uuid`,
+        [totalPrice.toFixed(2), customerId]
+      );
+    }
+
     await client.query("COMMIT");
   } catch (error) {
     await client.query("ROLLBACK");

--- a/app/routes/manager.tsx
+++ b/app/routes/manager.tsx
@@ -27,9 +27,17 @@ interface Employee {
   start_date: string;
 }
 
+interface CustomerRow {
+  id:          string;
+  name:        string;
+  phone:       string;
+  points:      number;
+  orderCount:  number;
+}
+
 export async function loader({ request, context }: Route.LoaderArgs) {
   await requireSignedIn({ request, context });
-  const [itemsResult, employeesResult] = await Promise.all([
+  const [itemsResult, employeesResult, customersResult] = await Promise.all([
     pool.query(
       `SELECT item_id::text AS id, name, category, price::float AS price,
               is_active AS "onMenu", COALESCE(is_seasonal, false) AS "isSeasonal",
@@ -40,10 +48,21 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       `SELECT employee_id::text AS id, name, start_date::text
        FROM "Employee" ORDER BY name`
     ),
+    pool.query(
+      `SELECT c.customer_id::text AS id, c.name, c.phone_number AS phone,
+              COALESCE(c.points, 0)::int AS points,
+              COUNT(o.order_id)::int AS "orderCount"
+       FROM "Customer" c
+       LEFT JOIN "Order" o ON o.customer_id = c.customer_id
+       WHERE c.phone_number IS NOT NULL AND c.phone_number <> ''
+       GROUP BY c.customer_id, c.name, c.phone_number, c.points
+       ORDER BY c.points DESC`
+    ),
   ]);
   return {
     inventory: itemsResult.rows as InventoryItem[],
     employees: employeesResult.rows as Employee[],
+    customers: customersResult.rows as CustomerRow[],
   };
 }
 
@@ -226,7 +245,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   return { ok: false };
 }
 
-const TABS = ["Inventory", "Menu", "Employees", "Reports"] as const;
+const TABS = ["Inventory", "Menu", "Employees", "Customers", "Reports"] as const;
 
 const inputCls = "field-input text-sm";
 
@@ -249,7 +268,7 @@ function SeasonalToggle({ value, onChange }: { value: boolean; onChange: (v: boo
 }
 
 export default function Manager() {
-  const { inventory, employees } = useLoaderData<typeof loader>();
+  const { inventory, employees, customers } = useLoaderData<typeof loader>();
   const navigate  = useNavigate();
   const fetcher   = useFetcher<typeof action>();
 
@@ -601,6 +620,39 @@ export default function Manager() {
                   {busy ? "Deleting…" : "Delete selected"}
                 </button>
               </div>
+            </section>
+          )}
+
+          {activeTab === "Customers" && (
+            <section aria-label="Loyalty customers">
+              <h2 className="text-lg font-bold text-slate-900 mb-1">Loyalty Members</h2>
+              <p className="text-sm text-slate-500 mb-4">Customers who have provided a phone number. Sorted by points balance.</p>
+              {customers.length === 0 ? (
+                <p className="text-sm text-slate-400">No loyalty members yet.</p>
+              ) : (
+                <div className="section-card overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-slate-50 border-b border-slate-200 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide">
+                        <th className="px-4 py-3">Name</th>
+                        <th className="px-4 py-3">Phone</th>
+                        <th className="px-4 py-3 text-right">Points</th>
+                        <th className="px-4 py-3 text-right">Orders</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {customers.map((c) => (
+                        <tr key={c.id} className="hover:bg-slate-50 transition-colors">
+                          <td className="px-4 py-3 font-medium text-slate-800">{c.name ?? "—"}</td>
+                          <td className="px-4 py-3 text-slate-500">{c.phone}</td>
+                          <td className="px-4 py-3 text-right font-semibold text-indigo-600">{c.points.toLocaleString()}</td>
+                          <td className="px-4 py-3 text-right text-slate-500">{c.orderCount}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </section>
           )}
 

--- a/app/routes/manager.tsx
+++ b/app/routes/manager.tsx
@@ -236,6 +236,17 @@ export async function action({ request, context }: Route.ActionArgs) {
     return { ok: true };
   }
 
+  if (intent === "edit-customer") {
+    const id    = formData.get("id")    as string;
+    const name  = formData.get("name")  as string;
+    const phone = (formData.get("phone") as string).replace(/\D/g, "");
+    await pool.query(
+      `UPDATE "Customer" SET name = $1, phone_number = $2 WHERE customer_id = $3::uuid`,
+      [name, phone, id]
+    );
+    return { ok: true };
+  }
+
   if (intent === "delete-employee") {
     const id = formData.get("id") as string;
     await pool.query(`DELETE FROM "Employee" WHERE employee_id = $1::uuid`, [id]);
@@ -302,6 +313,8 @@ export default function Manager() {
   const [selectedEmployee, setSelectedEmployee] = useState<string | null>(null);
   const [showAddEmployee, setShowAddEmployee]   = useState(false);
   const [editEmployee, setEditEmployee]         = useState<Employee | null>(null);
+  const [selectedCustomer, setSelectedCustomer] = useState<string | null>(null);
+  const [editCustomer, setEditCustomer]         = useState<CustomerRow | null>(null);
 
   // Close modals after add/edit; update report text when returned
   useEffect(() => {
@@ -642,7 +655,15 @@ export default function Manager() {
                     </thead>
                     <tbody className="divide-y divide-slate-100">
                       {customers.map((c) => (
-                        <tr key={c.id} className="hover:bg-slate-50 transition-colors">
+                        <tr
+                          key={c.id}
+                          onClick={() => setSelectedCustomer(selectedCustomer === c.id ? null : c.id)}
+                          tabIndex={0}
+                          onKeyDown={(e) => e.key === "Enter" && setSelectedCustomer(selectedCustomer === c.id ? null : c.id)}
+                          aria-selected={selectedCustomer === c.id}
+                          className={`cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-600
+                            ${selectedCustomer === c.id ? "bg-blue-50" : "hover:bg-slate-50"}`}
+                        >
                           <td className="px-4 py-3 font-medium text-slate-800">{c.name ?? "—"}</td>
                           <td className="px-4 py-3 text-slate-500">{c.phone}</td>
                           <td className="px-4 py-3 text-right font-semibold text-indigo-600">{c.points.toLocaleString()}</td>
@@ -653,6 +674,18 @@ export default function Manager() {
                   </table>
                 </div>
               )}
+              <div className="mt-3">
+                <button
+                  onClick={() => {
+                    const c = customers.find((c) => c.id === selectedCustomer);
+                    if (c) setEditCustomer(c);
+                  }}
+                  disabled={!selectedCustomer}
+                  className="secondary-btn px-4 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Edit selected
+                </button>
+              </div>
             </section>
           )}
 
@@ -801,6 +834,40 @@ export default function Manager() {
                 </button>
                 <button type="submit" disabled={busy} className="primary-btn flex-1 py-2.5 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 transition-colors disabled:opacity-60">
                   {busy ? "Adding…" : "Add Employee"}
+                </button>
+              </div>
+            </fetcher.Form>
+          </div>
+        </div>
+      )}
+
+      {/* Edit Customer Modal */}
+      {editCustomer && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={(e) => { if (e.target === e.currentTarget) setEditCustomer(null); }}
+        >
+          <div className="surface-card w-full max-w-sm p-6">
+            <h2 className="text-xl font-bold text-slate-900 mb-5">Edit Customer</h2>
+            <fetcher.Form method="post" className="flex flex-col gap-4">
+              <input type="hidden" name="intent" value="edit-customer" />
+              <input type="hidden" name="id" value={editCustomer.id} />
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Name</label>
+                <input name="name" defaultValue={editCustomer.name ?? ""} required className={inputCls} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Phone</label>
+                <input name="phone" type="tel" defaultValue={editCustomer.phone} required className={inputCls} />
+              </div>
+              <div className="flex gap-3 mt-2">
+                <button type="button" onClick={() => setEditCustomer(null)} className="secondary-btn flex-1 py-2.5 focus:outline-none transition-colors">
+                  Cancel
+                </button>
+                <button type="submit" disabled={busy} className="primary-btn flex-1 py-2.5 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 transition-colors disabled:opacity-60">
+                  {busy ? "Saving…" : "Save Changes"}
                 </button>
               </div>
             </fetcher.Form>


### PR DESCRIPTION
database changes:
- added customer_name text and order_number int columns to "Order"
- created order_number_seq sequence: goes from 1-100 and cycles

cashier.tsx:
- Phone number lookup: finds customer by normalized phone number
- Customer resolution on order submit: uses customer_id from phone lookup, creates customer by phone, or falls back to default
- Points earning: floor(discounted_total * 5) added per order inside the transaction
- Points redemption: 300-pt ($4) and 100-pt ($1) discount bundles, discount applied to order total, redeemed points deducted in the same UPDATE
- UI: phone input + lookup button, found/not-found feedback, redemption panel with live total, customer name field

customer.tsx:
- Same lookup, resolution, earning, and redemption logic as cashier
- Redemption panel and phone lookup appear in the cart review
- Phone is labeled optional; skipping it orders anonymously with no points

manager.tsx:
- Added customers query to the loader (joins Customer to Order for order count)
- Added Customers tab to the navigation sidebar
- Added a loyalty members table sorted by points balance 